### PR TITLE
fixed the shorthand issue #7

### DIFF
--- a/firetower
+++ b/firetower
@@ -195,7 +195,7 @@ function get_flag() {
 
 function should_preserve_scrollback() {
   for var in "$@" ; do
-    if [[ $var == --preserve-scrollback ]] ; then
+    if [[ $var == --preserve-scrollback ]] || [[ $var == -p ]] ; then
       return 0
     fi
   done
@@ -203,10 +203,15 @@ function should_preserve_scrollback() {
 }
 
 function get_directory() {
-  for var in "$@"
-  do
-    if [[ $var == --directory=* ]] ; then
-      echo "$var" | cut -d '=' -f 2
+  for (( i=1; i<=$#; i++)); do
+    j=$((i+1))
+    local flag=${!i}
+    local dir_name=${!j}
+    if ( [[ $flag == -d ]] && [[ $dir_name == * ]] ) ; then
+      echo "$dir_name"
+      return
+    elif ( [[ $flag == --directory=* ]] ) ; then
+      echo "$flag" | cut -d '=' -f 2
       return
     fi
   done


### PR DESCRIPTION
In response to the problems of the pull request "Shorthand issue #10" , this is a cleaner pull request for the issue "shorthand flags for option arguments #7" .

Made changes such that the scrollback is preserved on each restart even when "-p" is entered instead of "--preserve-scrollback" and also changed the code such that the current working directory is changed to the specified directory even when "-d dir_name" argument is passed instead of "--directory=dir_name" . The upside of this solution is that we do not need to type in the long command and have a shorthand flag for them. However, they work for their longer counterparts too.

To preserve scrollback, we have added the condition to check if the argument is "--preserve-scrollback" or "-p" . If it is any one of them, then the scrollback is preserved.

To change the current directory to a specified directory, we have searched for "-d" and "--directory=" using $# which contains the number of arguments passed. If "--directory=" is found, then the condition remains same as of the initial code whereas if "-d " is found, then the next argument is read which specifies the new directory.